### PR TITLE
Remove Sending order print

### DIFF
--- a/gamemodes/mapsweepers/gamemode/sh_net.lua
+++ b/gamemodes/mapsweepers/gamemode/sh_net.lua
@@ -289,7 +289,6 @@ if SERVER then
 			local _i =  i + 1
 			timer.Simple(i*delay, function()
 				jcms.net_SendOrder(orderId, orderData)
-				jcms.printf("Sending order %d/%d", _i, count)
 			end)
 			i = i + 1
 		end


### PR DESCRIPTION
Removes a debug print that gets rather spammy on a multiplayer server
<img width="418" height="619" alt="image" src="https://github.com/user-attachments/assets/3f84c59b-c0a6-484f-b667-984f905e1dbe" />
