### PR TITLE
Send weapon prices all at once

### DIFF
--- a/gamemodes/mapsweepers/gamemode/init.lua
+++ b/gamemodes/mapsweepers/gamemode/init.lua
@@ -437,7 +437,7 @@ end
 
 		timer.Simple(4.0, function()
 			if IsValid(ply) and not ply:IsBot() then
-				jcms.net_SendManyWeapons(jcms.weapon_prices, ply)
+				jcms.net_SendWeaponPrices(jcms.weapon_prices, ply)
 			end
 		end)
 	end)

--- a/gamemodes/mapsweepers/gamemode/sv_tutorial.lua
+++ b/gamemodes/mapsweepers/gamemode/sv_tutorial.lua
@@ -182,7 +182,7 @@ hook.Add("Think", "jcms_TutorialThink", function()
 				weapon_crossbow = 699
 			}
 			
-			jcms.net_SendManyWeapons(jcms.weapon_prices, ply)
+			jcms.net_SendWeaponPrices(jcms.weapon_prices, ply)
 		end
 		
 		if #ply:GetWeapons() > 1 then


### PR DESCRIPTION
Currently sweps are slowly sent by a timer to the client which makes the client wait for the weapons to load, this pr makes it so it sends them all at once compressed so they just instantly load.