### PR TITLE
Net improvements

### DIFF
--- a/gamemodes/mapsweepers/gamemode/init.lua
+++ b/gamemodes/mapsweepers/gamemode/init.lua
@@ -418,7 +418,7 @@ end
 		jcms.net_NotifySquadChange(ply, true)
 		jcms.net_SendFogData(ply) --Currently doesn't update/assumes the fog stays static. Might cause weird behaviour on maps that edit their fog. 
 		jcms.net_SendManyOrders(jcms.orders, ply)
-		jcms.net_SendManyWeapons(jcms.weapon_prices, ply)
+		jcms.net_SendWeaponPrices(jcms.weapon_prices, ply)
 		jcms.net_ShareMissionData(jcms.mission_GetObjectives(), ply)
 	end)
 

--- a/gamemodes/mapsweepers/gamemode/init.lua
+++ b/gamemodes/mapsweepers/gamemode/init.lua
@@ -389,10 +389,6 @@ end
 		return true
 	end)
 
-	gameevent.Listen("player_activate") 
-	-- Am I missing something? Why do we even have to fucking do this? We've already
-	-- got a fucking hook for player_disconnect, that is, GM:PlayerDisconnected. Why
-	-- couldn't they do something like this here, too?
 	hook.Add("jcms_PlayerNetReady", "jcms_OnActivate", function(ply)
 		local sid64 = ply:SteamID64()
 		if jcms.director and jcms.director.persisting_loadout then

--- a/gamemodes/mapsweepers/gamemode/init.lua
+++ b/gamemodes/mapsweepers/gamemode/init.lua
@@ -419,7 +419,11 @@ end
 		jcms.net_SendFogData(ply) --Currently doesn't update/assumes the fog stays static. Might cause weird behaviour on maps that edit their fog. 
 		jcms.net_SendManyOrders(jcms.orders, ply)
 		jcms.net_SendWeaponPrices(jcms.weapon_prices, ply)
-		jcms.net_ShareMissionData(jcms.mission_GetObjectives(), ply)
+
+		local currentObjectives = jcms.mission_GetObjectives()
+		if #currentObjectives > 0 then
+			jcms.net_ShareMissionData(currentObjectives, ply)
+		end
 	end)
 
 	hook.Add("PlayerDisconnected", "jcms_OnDisconnect", function(ply)

--- a/gamemodes/mapsweepers/gamemode/sh_net.lua
+++ b/gamemodes/mapsweepers/gamemode/sh_net.lua
@@ -39,6 +39,7 @@ local bits_ply, bits_ent, bits_wld = 2, 2, 4
 		local WLD_ANNOUNCER = 7
 		local WLD_FOG = 8
 		local WLD_ANNOUNCER_UPDATE = 9
+		local WLD_WEAPON_PRICES = 10
 	-- // }}}
 
 	-- // CLIENT {{{
@@ -542,19 +543,17 @@ if SERVER then
 		end
 	end
 	
-	function jcms.net_SendManyWeapons(weapons, to)
-		local delay = 0.028
-		local count = table.Count(weapons)
-		local i = 0
-		
-		for weaponClass, weaponCost in pairs(weapons) do
-			local _i =  i + 1
-			timer.Simple(i*delay, function()
-				jcms.net_SendWeapon(weaponClass, weaponCost, to)
-				--jcms.printf("Sending weapon %d/%d", _i, count)
-			end)
-			i = i + 1
-		end
+	function jcms.net_SendWeaponPrices(weapons, to)
+		local weaponsData = util.TableToJSON(weapons)
+		local compressed = util.Compress(weaponsData)
+
+		net.Start("jcms_msg")
+			net.WriteBool(false)
+			net.WriteEntity(game.GetWorld())
+			net.WriteUInt(WLD_WEAPON_PRICES, bits_wld)
+			net.WriteUInt(#compressed, 16)
+			net.WriteData(compressed, #compressed)
+		net.Send(to)
 	end
 
 	function jcms.net_SendWeaponInLoadout(class, n, to)
@@ -981,6 +980,17 @@ if CLIENT then
 				else
 					jcms.weapon_loadout[class] = nil
 				end
+			end
+		end,
+
+		[ WLD_WEAPON_PRICES ] = function()
+			local compressedSize = net.ReadUInt(16)
+			local compressedData = net.ReadData(compressedSize)
+			local weaponsData = util.Decompress(compressedData)
+			local wepsPrices = util.JSONToTable(weaponsData)
+
+			for class, price in pairs(wepsPrices) do
+				jcms.weapon_prices[ class ] = price
 			end
 		end,
 

--- a/gamemodes/mapsweepers/gamemode/sv_tutorial.lua
+++ b/gamemodes/mapsweepers/gamemode/sv_tutorial.lua
@@ -182,7 +182,7 @@ hook.Add("Think", "jcms_TutorialThink", function()
 				weapon_crossbow = 699
 			}
 			
-			jcms.net_SendManyWeapons(jcms.weapon_prices, ply)
+			jcms.net_SendWeaponPrices(jcms.weapon_prices, ply)
 		end
 		
 		if #ply:GetWeapons() > 1 then

--- a/gamemodes/mapsweepers/gamemode/sv_tutorial.lua
+++ b/gamemodes/mapsweepers/gamemode/sv_tutorial.lua
@@ -42,7 +42,7 @@ hook.Add("InitPostEntity", "jcms_TutorialBuild", function()
 	jcms.tutorialEnts._terminal1 = terminal
 end)
 
-hook.Add("player_activate", "jcms_tutorialOnActivate", function(data)
+hook.Add("jcms_PlayerNetReady", "jcms_tutorialOnActivate", function(data)
 	local objectives = {
 		{ type = "tutorialphase0", progress = 0, total = 0 }
 	}


### PR DESCRIPTION
- Adds a new `jcms_PlayerNetReady` hook that indicates when the player is ready to receive net messages after spawning in, uses this hook instead of `player_activate`
- Removes the timers in the previous `player_activate` logic as it isn't needed anymore
- Sends `net_ShareMissionData` on join so players can always see objectives
- Sends weapons in one compressed net message so they don't appear to be "loading" clientside