### PR TITLE
Adjust ammo efficiency cost

### DIFF
--- a/gamemodes/mapsweepers/gamemode/init.lua
+++ b/gamemodes/mapsweepers/gamemode/init.lua
@@ -2457,6 +2457,14 @@ end
 		weapon_dredux_de_supershotgun = 699,
 		weapon_dredux_de_unmaker = 1999,
 
+		-- ARCCW GSO
+		arccw_go_nade_frag = 399,
+		arccw_go_nade_incendiary = 399,
+		arccw_go_nade_molotov = 399,
+		arccw_go_nade_smoke = 99,
+		arccw_go_nade_flash = 99,
+		arccw_go_nade_knife = 99,
+
 		-- Other
 		ultra_rail_gun = 1999,
 		weapon_undertale_sans = 3799,

--- a/gamemodes/mapsweepers/gamemode/shared.lua
+++ b/gamemodes/mapsweepers/gamemode/shared.lua
@@ -734,8 +734,7 @@ jcms.vectorOne = Vector(1, 1, 1)
 
 		-- // Calculate our average time between shots, accounting for reload. {{{
 			local fullCycle = (stats.firerate * math.max(stats.clipsize, 1)) + stats.reloadtime
-			local avgFireRate = fullCycle / math.max(stats.clipsize, 1)
-			avgFireRate = 1 / avgFireRate
+			local avgFireRate = math.max(stats.clipsize, 1) / fullCycle
 
 			if math.max(stats.clipsize, 1) == 1 then --If we only have 1 shot, only one of these values matters.
 				avgFireRate = math.min(1/stats.reloadtime, stats.firerate_rps)
@@ -768,10 +767,11 @@ jcms.vectorOne = Vector(1, 1, 1)
 
 		--Stat weighting.
 		local scaledDPSCost = ( kps + (dpsCost / 50) ) * 50/2
-		local scaledEfficiencyCost = ammoEfficiency^(2/3)
+		local scaledEfficiencyCost = ammoEfficiency^(2/3) / 10
 
 		--Final cost.
-		local cost = (scaledDPSCost * scaledEfficiencyCost + starterClipCost) * 2.75
+		local costMult = 2.75 * 4.85 // Arbitrary multiplier to keep prices stable when changing calculations
+		local cost = (scaledDPSCost * scaledEfficiencyCost + starterClipCost) * costMult
 
 		local divider = 5		-- Never noticed this, but I like it -J.
 		if cost >= 2000 then


### PR DESCRIPTION
Adjusts ammo efficiency cost multiplier to be a much smaller factor in total weapon cost. While ammo efficiency is useful, weapons with poor stats but cheap ammo should not cost much more than weapons with better stats and slightly more expensive ammo (pistols, rifles).
Slightly refactors price calculation to use a variable in final price calculation rather than a raw number. Also increases this final multiplication to keep total prices approximately the same as before, but I'm of course open to tweaks.
Adds fixed prices for ArcCW GSO grenades, since the new calculation method makes them way too cheap (~38 J) and because I use ArcCW GSO.