### PR TITLE
Change evac movetype to none

### DIFF
--- a/gamemodes/mapsweepers/entities/entities/jcms_evac.lua
+++ b/gamemodes/mapsweepers/entities/entities/jcms_evac.lua
@@ -33,6 +33,7 @@ function ENT:Initialize()
 
 	if SERVER then
 		self.nextSlowCharge = CurTime()
+		self:SetMoveType(MOVETYPE_NONE)
 		self:PhysicsInitStatic(SOLID_VPHYSICS)
 	end
 


### PR DESCRIPTION
Might fix the antlion guard trampoline bug, doesn't hurt setting it regardless.