### PR TITLE
Always allow players to stop noclipping

### DIFF
--- a/gamemodes/mapsweepers/gamemode/init.lua
+++ b/gamemodes/mapsweepers/gamemode/init.lua
@@ -1142,6 +1142,8 @@ end
 	end
 
 	function GM:PlayerNoClip(ply, flying)
+		if not flying then return true end -- Always allow stopping noclip
+
 		if jcms.director and jcms.director.debug then
 			return true
 		else


### PR DESCRIPTION
Makes it so players can always disable noclip, just not start it.

Helps when admins use !noclip etc.