### PR TITLE
Support for custom multipliers from capable weapon bases

### DIFF
--- a/gamemodes/mapsweepers/gamemode/shared.lua
+++ b/gamemodes/mapsweepers/gamemode/shared.lua
@@ -503,7 +503,10 @@ jcms.vectorOne = Vector(1, 1, 1)
 						dmg = GetConVar("arccw_mult_damage"):GetFloat() or 1.0,
 						rpm = GetConVar("arccw_mult_rpm"):GetFloat() or 1.0,
 						moa = GetConVar("arccw_mult_accuracy"):GetFloat() or 1.0
-					}
+					}				/*
+					if WepBaseMod.ArcCW.dmg ~= GetConVar("arccw_mult_npcdamage"):GetFloat() then --Inconsistant damage handler
+					end
+					*/
 				end
 
 				local ammotype = game.GetAmmoName( game.GetAmmoID(tostring(gunData.Primary.Ammo) or "") or tonumber(gunData.Primary.Ammo)  ) or "none"

--- a/gamemodes/mapsweepers/gamemode/shared.lua
+++ b/gamemodes/mapsweepers/gamemode/shared.lua
@@ -585,6 +585,16 @@ jcms.vectorOne = Vector(1, 1, 1)
 				stats.accuracy = (tonumber(gunData.Spread) or 0)
 			elseif gunData.Base == "mg_base" then --MW Base --TODO: See if there's a better way to detect this base.
 				stats.base = "MW Base"
+				if not WepBaseMod.MW then
+					WepBaseMod.MW = {
+						dmg = GetConVar("mgbase_sv_pvedamage"):GetFloat() or 1.0,
+						moa = GetConVar("mgbase_sv_accuracy"):GetFloat() or 1.0
+					}
+					/*
+					if WepBaseMod.MW.dmg ~= GetConVar("mgbase_sv_pvpdamage"):GetFloat() then --Inconsistant damage handler
+					end
+					*/
+				end
 
 				local ammotype = game.GetAmmoName( game.GetAmmoID(tostring(gunData.Primary.Ammo) or "") or tonumber(gunData.Primary.Ammo)  ) or "none"
 				stats.ammotype_lkey = ammotype .. "_ammo"
@@ -595,9 +605,11 @@ jcms.vectorOne = Vector(1, 1, 1)
 				stats.numshots = gunData.Bullet.NumBullets or 1
 
 				stats.damage = gunData.Bullet.Damage[1] / stats.numshots
+				stats.damage = stats.damage * WepBaseMod.MW.dmg
 				stats.firerate = 60/gunData.Primary.RPM
 
 				stats.accuracy = (gunData.Cone.Hip) or 0 --Not 100% sure I've done this correctly - j
+				stats.accuracy = stats.accuracy / WepBaseMod.MW.moa
 				radAccuracy = false
 			elseif string.StartsWith(gunData.Base or "", "draconic_") then --Draconic Base -- TODO: See if there's a better way to detect this base
 				stats.base = "Draconic"

--- a/gamemodes/mapsweepers/gamemode/shared.lua
+++ b/gamemodes/mapsweepers/gamemode/shared.lua
@@ -435,6 +435,8 @@ jcms.vectorOne = Vector(1, 1, 1)
 		["frag grenades"] = true,
 	}
 
+	local WepBaseMod = {}
+
 	function jcms.gunstats_GetExpensive(class)
 		local gunData = weapons.Get(class) or jcms.default_weapons_datas[class]
 		if not gunData then return end
@@ -545,6 +547,14 @@ jcms.vectorOne = Vector(1, 1, 1)
 				-- Arc9
 				stats.base = "ARC9"
 
+				if not WepBaseMod.ARC9 then
+					WepBaseMod.ARC9 = {
+						dmg = GetConVar("arc9_mod_damage"):GetFloat() or 1.0,
+						rpm = GetConVar("arc9_mod_rpm"):GetFloat() or 1.0,
+						moa = GetConVar("arc9_mod_spread"):GetFloat() or 1.0
+					}
+				end
+
 				local ammotype = game.GetAmmoName( game.GetAmmoID(tostring(gunData.Ammo) or "") or tonumber(gunData.Ammo)  ) or "none"
 				stats.ammotype_lkey = ammotype .. "_ammo"
 				stats.ammotype = ammotype:lower()
@@ -553,9 +563,12 @@ jcms.vectorOne = Vector(1, 1, 1)
 				stats.numshots = gunData.Num or 1
 
 				stats.damage = gunData.DistributeDamage and math.Round( gunData.DamageMax / stats.numshots, 1 ) or gunData.DamageMax
+				stats.damage = stats.damage * WepBaseMod.ARC9.dmg
 				stats.firerate = 60/gunData.RPM
+				stats.firerate = stats.firerate / WepBaseMod.ARC9.rpm
 
 				stats.accuracy = (tonumber(gunData.Spread) or 0) + (tonumber(gunData.SpreadAddHipFire) or 0)
+				stats.accuracy = stats.accuracy * WepBaseMod.ARC9.moa
 			elseif gunData.ArcticTacRP then
 				stats.base = "Tactical RP"
 

--- a/gamemodes/mapsweepers/gamemode/shared.lua
+++ b/gamemodes/mapsweepers/gamemode/shared.lua
@@ -498,6 +498,13 @@ jcms.vectorOne = Vector(1, 1, 1)
 			elseif gunData.ArcCW then
 				-- ArcCW
 				stats.base = "ArcCW"
+				if not WepBaseMod.ArcCW then
+					WepBaseMod.ArcCW = {
+						dmg = GetConVar("arccw_mult_damage"):GetFloat() or 1.0,
+						rpm = GetConVar("arccw_mult_rpm"):GetFloat() or 1.0,
+						moa = GetConVar("arccw_mult_accuracy"):GetFloat() or 1.0
+					}
+				end
 
 				local ammotype = game.GetAmmoName( game.GetAmmoID(tostring(gunData.Primary.Ammo) or "") or tonumber(gunData.Primary.Ammo)  ) or "none"
 				stats.ammotype_lkey = ammotype .. "_ammo"
@@ -507,9 +514,12 @@ jcms.vectorOne = Vector(1, 1, 1)
 				stats.numshots = gunData.Num or 1
 
 				stats.damage = math.Round( (gunData.Damage or 0) / stats.numshots, 1 )
+				stats.damage = stats.damage * WepBaseMod.ArcCW.dmg
 				stats.firerate = gunData.Delay or 0
+				stats.firerate = stats.firerate * WepBaseMod.ArcCW.rpm
 				stats.automatic = gunData.Primary.Automatic
 				stats.accuracy = (gunData.AccuracyMOA or 0)/60
+				stats.accuracy = stats.accuracy * WepBaseMod.ArcCW.moa
 				radAccuracy = false
 			elseif gunData.CW20Weapon then
 				-- Chuck's Weaponry 2.0

--- a/gamemodes/mapsweepers/gamemode/shared.lua
+++ b/gamemodes/mapsweepers/gamemode/shared.lua
@@ -516,8 +516,7 @@ jcms.vectorOne = Vector(1, 1, 1)
 				stats.clipsize = gunData.Primary.ClipSize or 0
 				stats.numshots = gunData.Num or 1
 
-				stats.damage = math.Round( (gunData.Damage or 0) / stats.numshots, 1 )
-				stats.damage = stats.damage * WepBaseMod.ArcCW.dmg
+				stats.damage = math.Round( (gunData.Damage or 0) * WepBaseMod.ArcCW.dmg / stats.numshots, 1 )
 				stats.firerate = gunData.Delay or 0
 				stats.firerate = stats.firerate * WepBaseMod.ArcCW.rpm
 				stats.automatic = gunData.Primary.Automatic
@@ -575,8 +574,7 @@ jcms.vectorOne = Vector(1, 1, 1)
 				stats.clipsize = gunData.ClipSize
 				stats.numshots = gunData.Num or 1
 
-				stats.damage = gunData.DistributeDamage and math.Round( gunData.DamageMax / stats.numshots, 1 ) or gunData.DamageMax
-				stats.damage = stats.damage * WepBaseMod.ARC9.dmg
+				stats.damage = gunData.DistributeDamage and math.Round( gunData.DamageMax * WepBaseMod.ARC9.dmg / stats.numshots, 1 ) or gunData.DamageMax * WepBaseMod.ARC9.dmg
 				stats.firerate = 60/gunData.RPM
 				stats.firerate = stats.firerate / WepBaseMod.ARC9.rpm
 
@@ -617,8 +615,7 @@ jcms.vectorOne = Vector(1, 1, 1)
 
 				stats.numshots = gunData.Bullet.NumBullets or 1
 
-				stats.damage = gunData.Bullet.Damage[1] / stats.numshots
-				stats.damage = stats.damage * WepBaseMod.MW.dmg
+				stats.damage = gunData.Bullet.Damage[1] * WepBaseMod.MW.dmg / stats.numshots
 				stats.firerate = 60/gunData.Primary.RPM
 
 				stats.accuracy = (gunData.Cone.Hip) or 0 --Not 100% sure I've done this correctly - j


### PR DESCRIPTION
Primarily focusing on MW and most of Arctic's weapon bases, custom multipliers for damage, firerate, accuracy, etc, will be factored into stats mainly to improve automatic price calculations should one want similarly balanced weapons.

Shotgun values seem to be scuffed but value adjustments will be up to the weapon creator.

TacRP is currently TODO, damage modifiers are seperated across ammo types, there exists a helper function only usable to weapon instances.